### PR TITLE
fix: catch errors from gh rejecting

### DIFF
--- a/src/getGitHubAuthToken.test.ts
+++ b/src/getGitHubAuthToken.test.ts
@@ -36,7 +36,7 @@ describe("getGitHubAuthToken", () => {
 		expect(actual).toEqual({ succeeded: true, token: stdout });
 	});
 
-	it("returns the gh error when gh auth token and gh error", async () => {
+	it("returns the gh error when gh auth token and gh resolve with errors", async () => {
 		const stderr = "Oh no!";
 
 		mockExec.mockResolvedValueOnce({ stderr: "auth token issue" });
@@ -50,7 +50,7 @@ describe("getGitHubAuthToken", () => {
 		});
 	});
 
-	it("returns the gh auth token error when only gh auth token errors", async () => {
+	it("returns the gh auth token error when only gh auth token resolves with an error", async () => {
 		const stderr = "Oh no!";
 
 		mockExec.mockResolvedValueOnce({ stderr });
@@ -64,7 +64,7 @@ describe("getGitHubAuthToken", () => {
 		});
 	});
 
-	it("returns undefined when both gh and gh auth token print nothing", async () => {
+	it("returns undefined when both gh and gh auth token resolve with nothing", async () => {
 		mockExec.mockResolvedValueOnce({ stderr: "", stdout: "" });
 		mockExec.mockResolvedValueOnce({ stderr: "", stdout: "" });
 
@@ -72,6 +72,18 @@ describe("getGitHubAuthToken", () => {
 
 		expect(actual).toEqual({
 			error: undefined,
+			succeeded: false,
+		});
+	});
+
+	it("returns undefined when both gh and gh auth token reject with errors", async () => {
+		mockExec.mockRejectedValueOnce(new Error("Oh no! (1)"));
+		mockExec.mockRejectedValueOnce(new Error("Oh no! (2)"));
+
+		const actual = await getGitHubAuthToken();
+
+		expect(actual).toEqual({
+			error: "Could not run `gh`: Error: Oh no! (2)",
 			succeeded: false,
 		});
 	});

--- a/src/getGitHubAuthToken.ts
+++ b/src/getGitHubAuthToken.ts
@@ -9,13 +9,15 @@ export async function getGitHubAuthToken(): Promise<GitHubAuthToken> {
 	}
 
 	const exec = util.promisify(cp.exec);
-	const token = await exec("gh auth token");
+	const token = await exec("gh auth token").catch(
+		(): Record<string, string | undefined> => ({}),
+	);
 
 	if (token.stdout) {
 		return { succeeded: true, token: token.stdout };
 	}
 
-	const help = await exec("gh");
+	const help = await exec("gh").catch((error) => ({ stderr: error }));
 
 	return {
 		error:

--- a/src/getGitHubAuthToken.ts
+++ b/src/getGitHubAuthToken.ts
@@ -17,7 +17,9 @@ export async function getGitHubAuthToken(): Promise<GitHubAuthToken> {
 		return { succeeded: true, token: token.stdout };
 	}
 
-	const help = await exec("gh").catch((error) => ({ stderr: error }));
+	const help = await exec("gh").catch((error: unknown) => ({
+		stderr: error as string,
+	}));
 
 	return {
 		error:


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #364
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/get-github-auth-token/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/get-github-auth-token/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Handles both the first `gh auth token` call and the following `gh` call rejecting.

💖 